### PR TITLE
Support nested package names in proto files (i.e. pkg.v1)

### DIFF
--- a/test/fixture/nested.proto
+++ b/test/fixture/nested.proto
@@ -1,0 +1,16 @@
+syntax="proto3";
+
+package greeter.v1;
+
+service NestedGreeter {
+  rpc Hello (Name) returns (Message) {}
+  rpc Goodbye (Name) returns (Message) {}
+}
+
+message Name {
+  string name = 1;
+}
+
+message Message {
+  string message = 1;
+}


### PR DESCRIPTION
I was trying to use grpc-kit with CSI (container attached storage) protofile but it failed because it does not supported nested packages (package names with dot separator). This fix works for me.