### PR TITLE
Expose gRPC Server Port

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ class GrpcServer {
   }
   
   listen(address, creds=grpc.ServerCredentials.createInsecure()){
-    this.server.bind(address, creds);
+    this.port = this.server.bind(address, creds);
     this.server.start();
     return this;
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -167,4 +167,9 @@ describe("grpc-kit", () => {
       done();
     });
   });
+
+  it("exposes the server's port number", (done) => {
+    assert(server.port === 50051);
+    done();
+  });
 });


### PR DESCRIPTION
Captures and exposes the result of making the call to `grpc.Server.bind`, so that users can check on which port the server is listening.

The driving force behind this change is that it's possible to specify a port number of `0` when creating a server. This causes grpc to generate a random free port number, which it returns as the result of calling `grpc.Server.bind`. In order to know what port number it chose, we need to capture this return value.